### PR TITLE
chore(travis): adds travis config to run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: php
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+before_script:
+  - composer self-update
+  - composer update --no-interaction
+script:
+  - vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
chore(travis): adds travis config to run unit tests (with coverage summary) on php70, php71, and php72

i didn't see a build kick off in my previous submission: #4 , so i took the liberty. the build output looks like this (on my fork): https://travis-ci.org/abacaphiliac/php-psr-testlogger/builds/390499022

if you are into this, you'll have to add your repo at travis-ci.org and enable the build. after that, i'd be happy to add a php-cs-fixer dry run command. that command will fail the build right now because some src and test files need to be fixed. we could also add a build badge to the readme.

thanks for a great test tool : )